### PR TITLE
New eval technique and out of frame ability

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -41,7 +41,7 @@ def _run(cfg: RuntimeConfig, ds_cls: TABEDataset | CustomDataset, vid_names) -> 
         outputs = generation_pipeline(all_ims_pil, query_mask, gt_vis_masks, gt_occlusion, gt_amodal_masks)
 
         visualiser = Visualiser(vis_out_dir)
-        visualiser.visualise(outputs, gt_amodal_masks)
+        visualiser.visualise(outputs)
 
         # If we have ground truth information we can run IoU evaluation
         if gt_amodal_masks is not None and gt_occlusion is not None and gt_vis_masks is not None:

--- a/src/runner.py
+++ b/src/runner.py
@@ -44,7 +44,7 @@ def _run(cfg: RuntimeConfig, ds_cls: TABEDataset | CustomDataset, vid_names) -> 
         visualiser.visualise(outputs)
 
         # If we have ground truth information we can run IoU evaluation
-        if gt_amodal_masks is not None and gt_occlusion is not None and gt_vis_masks is not None:
+        if gt_amodal_masks is not None and gt_occlusion is not None and gt_vis_masks is not None and cfg.img_padding == 0:
             vid_iou_results = get_iou_results(outputs.masks, gt_amodal_masks, gt_vis_masks,
                                               map_occlusion_levels([occl["level"] for occl in gt_occlusion]))
             print(vid_iou_results)

--- a/src/tabe/configs/runtime_config.py
+++ b/src/tabe/configs/runtime_config.py
@@ -67,3 +67,4 @@ class RuntimeConfig:
     or_orig_vis_mask: bool = True
     seed: int = 42
     added_bbox_perc: int = 0  # If there is any extension wanted on predicted bounding boxes
+    img_padding: int = 0  # Pixels of padding for the images if predictions are wanted to go beyond the frame limit

--- a/src/tabe/pipelines/video_diffusion_pipeline.py
+++ b/src/tabe/pipelines/video_diffusion_pipeline.py
@@ -37,7 +37,8 @@ class VideoDiffusionPipeline:
     def _load_components(self):
         # For now we just load the components onto the cpu so we can put on gpu when required
         self.noise_scheduler = DDIMScheduler(**OmegaConf.to_container(self.cfg["noise_scheduler_kwargs"]))
-        self.vae = AutoencoderKL.from_pretrained(self.cfg.sd_inpainting_model_path, subfolder="vae")
+        self.vae = AutoencoderKL.from_pretrained(self.cfg.sd_inpainting_model_path, subfolder="vae",
+                                                 use_safetensors=False)
         self.tokenizer = CLIPTokenizer.from_pretrained(self.cfg.sd_inpainting_model_path, subfolder="tokenizer")
         self.text_encoder = CLIPTextModel.from_pretrained(self.cfg.sd_inpainting_model_path, subfolder="text_encoder")
         self.unet = UNet3DConditionModel.from_pretrained_2d(

--- a/src/tabe/pipelines/video_mask_gen_pipeline.py
+++ b/src/tabe/pipelines/video_mask_gen_pipeline.py
@@ -13,6 +13,7 @@ from src.tabe.modules.visible_masks import predict_visible_masks
 from src.tabe.modules.occlusion_predictor import predict_occlusion
 from src.tabe.utils.occlusion_utils import map_occlusion_levels, OcclusionInfo, OcclusionLevel
 from src.tabe.utils.bbox_utils import add_h_w_perc_to_bbox
+from src.tabe.utils.run_utils import pad_inputs
 
 
 @dataclass
@@ -26,6 +27,7 @@ class ExtraGenerationOutputs:
     gen_frames: np.ndarray  # n_gen_videos, n_frames, h, w, 3
     gen_input_ims: np.ndarray  # n_frames, res, res, 3
     gen_input_masks: np.ndarray  # n_frames, res, res
+    gt_amodal_masks: Optional[np.ndarray]  # n_frames, h, w
 
 
 @dataclass
@@ -59,11 +61,20 @@ class VideoMaskGenerationPipeline:
         occlusion_info_with_amounts = self._get_pipeline_occlusion_levels(gt_occlusion, monodepth_results, np_ims,
                                                                           vis_masks)
         occlusion_levels = [occl.level for occl in occlusion_info_with_amounts]
-        estimated_bboxes = self._get_pipeline_estimated_bboxes(gt_amodal_masks, monodepth_results, occlusion_levels,
-                                                               vis_masks)
 
         # Train the diffusion model
         self.init_trained_models(all_ims_pil, vis_masks, occlusion_info_with_amounts)
+
+        # Now for inference
+        # Pad the inputs if required
+        if self.cfg.img_padding > 0:
+            all_ims_pil, vis_masks, np_ims, gt_amodal_masks, monodepth_results = pad_inputs(all_ims_pil, vis_masks,
+                                                                                            np_ims, gt_amodal_masks,
+                                                                                            monodepth_results,
+                                                                                            pad=self.cfg.img_padding)
+
+        estimated_bboxes = self._get_pipeline_estimated_bboxes(gt_amodal_masks, monodepth_results, occlusion_levels,
+                                                               vis_masks)
 
         # Inference
         chunks = self._chunk_video_for_inference(occlusion_levels)
@@ -85,7 +96,8 @@ class VideoMaskGenerationPipeline:
                                                                                            c_occlusion,
                                                                                            c_estimated_bboxes,
                                                                                            c_monodepth_results,
-                                                                                           self.cfg.sam_checkpoint)
+                                                                                           self.cfg.sam_checkpoint,
+                                                                                           self.cfg.img_padding > 0)
             for i in range(len(gen_masks)):
                 for j, c in enumerate(chunk):
                     all_pred_masks[i][c] = gen_masks[i][j]

--- a/src/tabe/pipelines/video_mask_gen_pipeline.py
+++ b/src/tabe/pipelines/video_mask_gen_pipeline.py
@@ -117,6 +117,7 @@ class VideoMaskGenerationPipeline:
                                      gen_frames=all_gen_frames,
                                      gen_input_ims=all_input_ims,
                                      gen_input_masks=all_input_masks,
+                                     gt_amodal_masks=gt_amodal_masks
                                  ))
 
     def _output_checker(self, all_pred_masks: np.ndarray, occlusion_info: List[OcclusionLevel]):

--- a/src/tabe/utils/mask_utils.py
+++ b/src/tabe/utils/mask_utils.py
@@ -79,6 +79,7 @@ def convert_one_to_three_channel(img):
 
 
 def convert_masks_to_correct_format(masks):
+    masks = masks.astype(np.uint8)
     if masks.ndim == 4:
         masks = masks[..., 0]  # Convert to a single channel
     if masks.max() <= 1:

--- a/src/tabe/utils/vis_utils.py
+++ b/src/tabe/utils/vis_utils.py
@@ -85,8 +85,7 @@ class Visualiser:
                                    overlay_mask_over_image(im, mask, color=self.pred_mask_col)])
             Image.fromarray(conc).save(out_dir_final_outputs_vis_frames / f"{frame_num}.jpg")
 
-    def visualise(self, outputs: GenerationOutputs, gt_amodal_masks: Optional[np.ndarray] = None,
-                  output_extra_vis: bool = True) -> None:
+    def visualise(self, outputs: GenerationOutputs, output_extra_vis: bool = True) -> None:
         n_vids_generated = outputs.masks.shape[0]
         print("Making final outputs vis")
         for vid_num in range(n_vids_generated):
@@ -101,7 +100,7 @@ class Visualiser:
 
             for vid_num in range(n_vids_generated):
                 self._visualise_masks(outputs.debugs.ims, outputs.debugs.vis_mask,
-                                      outputs.debugs.pred_masks[vid_num], gt_amodal_masks, vid_num)
+                                      outputs.debugs.pred_masks[vid_num], outputs.debugs.gt_amodal_masks, vid_num)
 
 
 def overlay_mask_over_image(image: np.ndarray, mask: np.ndarray, alpha: float = 0.5,


### PR DESCRIPTION
**New Eval technique:** 
- Update naming conventions 
- Take mean/std of runs rather than best frame across all videos as this was an unfair tester and we should take each video as independent to really test temporal consistency 

**Out of frame ability**
Within the runtime config _img_padding_ can now be set, which allows predictions to go outside the frame

**Misc**
Few minor corrections and checkers